### PR TITLE
[Fix] Fix not null not being set on postgres deparser

### DIFF
--- a/drivers/postgres/parser.go
+++ b/drivers/postgres/parser.go
@@ -269,9 +269,17 @@ func (d *postgresDriver) parseColumn(columnDefinition *pg_query.ColumnDef) *doma
 		parameters["size"] = columnDefinition.TypeName.Typmods[0].GetAConst().Val.GetInteger().Ival
 	}
 
+	isNotNull := false
+	for _, constraint := range columnDefinition.Constraints {
+		fmt.Printf("%s\n", constraint.GetConstraint().GetContype().String())
+		if constraint.GetConstraint().GetContype().String() == "CONSTR_NOTNULL" {
+			isNotNull = true
+		}
+	}
+
 	return &domain.Column{
 		Datatype:   datatype,
 		Parameters: parameters,
-		IsNotNull:  columnDefinition.IsNotNull,
+		IsNotNull:  isNotNull,
 	}
 }

--- a/drivers/postgres/parser.go
+++ b/drivers/postgres/parser.go
@@ -271,7 +271,6 @@ func (d *postgresDriver) parseColumn(columnDefinition *pg_query.ColumnDef) *doma
 
 	isNotNull := false
 	for _, constraint := range columnDefinition.Constraints {
-		fmt.Printf("%s\n", constraint.GetConstraint().GetContype().String())
 		if constraint.GetConstraint().GetContype().String() == "CONSTR_NOTNULL" {
 			isNotNull = true
 		}


### PR DESCRIPTION
Since the field isNotNull on the object created by the pg_query deparser is not being set correctly, I got the isNotNull information by checking the whole object generated by the deparser.